### PR TITLE
Add app entry point so build can launch

### DIFF
--- a/ROPSApp.swift
+++ b/ROPSApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+/// Entry point for the app so the built binary can launch.
+/// Without an `@main` `App` struct, the app installs but fails to open.
+@main
+struct ROPSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Provide an `@main` `App` struct to launch `ContentView`

## Testing
- `swiftc ROPSApp.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a360f049a48321a82e3adf289cdf9f