### PR TITLE
Add Stripes for Skills PDF filler

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1789,6 +1789,8 @@ struct SASDetailView: View {
     private let notif = NotificationService()
     @State private var shareURL: URL?
     @State private var showShare = false
+    @State private var stripesURL: URL?
+    @State private var showStripesShare = false
 
     var body: some View {
         Form {
@@ -1811,6 +1813,28 @@ struct SASDetailView: View {
                     }
                 }
             }
+            Section("Stripes for Skills PDF") {
+                Button("Fill & Share Stripes for Skills") {
+                    do {
+                        if let url = Bundle.main.url(forResource: "BLANK STRIPES FOR SKILLS copy", withExtension: "pdf") {
+                            let data = StripesForSkillsData(
+                                applicantName: applicant.fullName,
+                                recruiterName: store.settings.recruiterName,
+                                recruiterInitials: store.settings.recruiterInitials,
+                                drill1: applicant.drillDate1,
+                                drill2: applicant.drillDate2
+                            )
+                            let out = try StripesForSkillsFiller.fill(templateURL: url, data: data)
+                            stripesURL = out
+                            showStripesShare = true
+                        } else {
+                            print("Template PDF not found in bundle")
+                        }
+                    } catch {
+                        print("Stripes PDF error: \(error)")
+                    }
+                }
+            }
         }
         .navigationTitle(applicant.fullName)
         .onChange(of: applicant.sasReminder) { value in
@@ -1829,6 +1853,9 @@ struct SASDetailView: View {
         }
         .sheet(isPresented: $showShare) {
             if let url = shareURL { ShareSheet(activityItems: [url]) }
+        }
+        .sheet(isPresented: $showStripesShare) {
+            if let url = stripesURL { ShareSheet(activityItems: [url]) }
         }
     }
 

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1817,14 +1817,14 @@ struct SASDetailView: View {
                 Button("Fill & Share Stripes for Skills") {
                     do {
                         if let url = Bundle.main.url(forResource: "BLANK STRIPES FOR SKILLS copy", withExtension: "pdf") {
-                            let data = StripesForSkillsData(
-                                applicantName: applicant.fullName,
+                            let input = SFSInput(
+                                applicantFullName: applicant.fullName,
                                 recruiterName: store.settings.recruiterName,
                                 recruiterInitials: store.settings.recruiterInitials,
                                 drill1: applicant.drillDate1,
                                 drill2: applicant.drillDate2
                             )
-                            let out = try StripesForSkillsFiller.fill(templateURL: url, data: data)
+                            let out = try StripesForSkillsFiller.fill(templateURL: url, input: input)
                             stripesURL = out
                             showStripesShare = true
                         } else {

--- a/StripesForSkillsFiller.swift
+++ b/StripesForSkillsFiller.swift
@@ -248,7 +248,6 @@ public enum StripesForSkillsFiller {
 
     private static func safeFieldName(_ ann: PDFAnnotation) -> String {
         if let n = ann.fieldName, !n.isEmpty { return n }
-        if let n = ann.value(forAnnotationKey: .fieldName) as? String, !n.isEmpty { return n }
         if let n = ann.value(forAnnotationKey: PDFAnnotationKey(rawValue: "T")) as? String, !n.isEmpty { return n }
         return ""
     }

--- a/StripesForSkillsFiller.swift
+++ b/StripesForSkillsFiller.swift
@@ -1,143 +1,268 @@
+//
+//  StripesForSkillsFiller.swift
+//  ROPS
+//
+//  iOS 16+ / PDFKit
+//  Fills the "BLANK STRIPES FOR SKILLS" PDF.
+//  - Top Name:  "PVT <Applicant Name>"
+//  - Top Unit:  "<Recruiter Name> / DET 3 RSP"
+//  - Top Date:  Second drill date
+//  - All "STRM Red Phase":   First drill date + recruiter initials
+//  - All "STRM White Phase": Second drill date + recruiter initials
+//  - Signature lines untouched
+//
+//  Usage (example):
+//    let input = SFSInput(applicantFullName: applicant.fullName,
+//                         recruiterName: store.settings.recruiterName,
+//                         recruiterInitials: store.settings.recruiterInitials,
+//                         drill1: applicant.drillDate1,
+//                         drill2: applicant.drillDate2)
+//    let url = try StripesForSkillsFiller.fill(templateURL: bundledPDFURL, input: input)
+//
 import Foundation
 import PDFKit
 import UIKit
 
-struct StripesForSkillsData {
-    let applicantName: String       // e.g., "John Doe"
-    let recruiterName: String       // e.g., from Settings.recruiterName
-    let recruiterInitials: String   // e.g., from Settings.recruiterInitials
-    let drill1: Date?               // First drill (Red Phase)
-    let drill2: Date?               // Second drill (White Phase & top Date)
+public struct SFSInput {
+    public let applicantFullName: String
+    public let recruiterName: String
+    public let recruiterInitials: String
+    public let drill1: Date?   // First drill
+    public let drill2: Date?   // Second drill
+
+    public init(applicantFullName: String,
+                recruiterName: String,
+                recruiterInitials: String,
+                drill1: Date?,
+                drill2: Date?) {
+        self.applicantFullName = applicantFullName
+        self.recruiterName = recruiterName
+        self.recruiterInitials = recruiterInitials
+        self.drill1 = drill1
+        self.drill2 = drill2
+    }
 }
 
-enum StripesForSkillsFiller {
+public enum StripesForSkillsFiller {
 
     // MARK: - Public entry point
-    static func fill(templateURL: URL, data: StripesForSkillsData) throws -> URL {
+
+    /// Returns a new, filled PDF file URL in the temporary directory.
+    public static func fill(templateURL: URL, input: SFSInput) throws -> URL {
         guard let doc = PDFDocument(url: templateURL), doc.pageCount > 0 else {
-            throw NSError(domain: "StripesFiller", code: -1, userInfo: [NSLocalizedDescriptionKey: "Template PDF not found or empty"])
+            throw NSError(domain: "StripesForSkills", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Template PDF not found or empty"])
         }
 
-        let df = DateFormatter(); df.dateStyle = .short
-        let d1 = data.drill1.map { df.string(from: $0) } ?? ""
-        let d2 = data.drill2.map { df.string(from: $0) } ?? ""
+        // Preferred: fill actual AcroForm fields (fast / crisp)
+        let touched = fillAcroFormIfPossible(in: doc, input: input)
+        let outURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SFS_\(UUID().uuidString).pdf")
 
-        // Render each page to a new PDF, drawing the original page, then our overlays.
-        let pageRect = doc.page(at: 0)?.bounds(for: .mediaBox) ?? CGRect(x: 0, y: 0, width: 612, height: 792)
-        let outURL = FileManager.default.temporaryDirectory.appendingPathComponent("STRIPES_\(UUID().uuidString).pdf")
-        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
+        if touched {
+            doc.write(to: outURL)
+            return outURL
+        }
+
+        // Fallback: render original pages and overlay text in the right places
+        return try renderWithOverlays(from: doc, input: input, outURL: outURL)
+    }
+
+    // MARK: - 1) AcroForm filling (preferred)
+
+    /// Iterates text widgets and sets values by robust name matching.
+    @discardableResult
+    private static func fillAcroFormIfPossible(in doc: PDFDocument, input: SFSInput) -> Bool {
+        var wrote = false
+        let df = DateFormatter(); df.dateStyle = .short
+        let d1 = input.drill1.map { df.string(from: $0) } ?? ""
+        let d2 = input.drill2.map { df.string(from: $0) } ?? ""
+
+        let topName  = "PVT \(input.applicantFullName)"
+        let topUnit  = "\(input.recruiterName) / DET 3 RSP"
+        let redText  = combine(date: d1, initials: input.recruiterInitials)
+        let whiteText = combine(date: d2, initials: input.recruiterInitials)
+
+        for p in 0..<doc.pageCount {
+            guard let page = doc.page(at: p) else { continue }
+            for ann in page.annotations where ann.widgetFieldType == .text {
+                let name = safeFieldName(ann)
+                guard !name.isEmpty else { continue }
+
+                // Top banner
+                if equals(name, "NAME  RANK") || containsAny(name, ["NAME & RANK", "NAMERANK"]) {
+                    ann.widgetStringValue = topName; wrote = true; continue
+                }
+                if equals(name, "PLATOON SGTUNIT") || containsAny(name, ["PLATOON", "UNIT"]) {
+                    ann.widgetStringValue = topUnit; wrote = true; continue
+                }
+                // Use *exact* "Date" match for the top right field (prevents touching bottom sig dates)
+                if equals(name, "Date") {
+                    ann.widgetStringValue = d2; wrote = true; continue
+                }
+
+                // Phase rows (accept several naming conventions)
+                let lower = name.lowercased()
+                if lower.contains("strm red phase") || lower.contains("red phase") {
+                    ann.widgetStringValue = redText; wrote = true; continue
+                }
+                if lower.contains("strm white phase") || lower.contains("white phase") {
+                    ann.widgetStringValue = whiteText; wrote = true; continue
+                }
+            }
+        }
+        return wrote
+    }
+
+    // MARK: - 2) Overlay fallback (text-anchored)
+
+    /// Draws original pages and overlays the values anchored to page text tokens.
+    private static func renderWithOverlays(from doc: PDFDocument, input: SFSInput, outURL: URL) throws -> URL {
+        let df = DateFormatter(); df.dateStyle = .short
+        let d1 = input.drill1.map { df.string(from: $0) } ?? ""
+        let d2 = input.drill2.map { df.string(from: $0) } ?? ""
+        let topName  = "PVT \(input.applicantFullName)"
+        let topUnit  = "\(input.recruiterName) / DET 3 RSP"
+        let redText  = combine(date: d1, initials: input.recruiterInitials)
+        let whiteText = combine(date: d2, initials: input.recruiterInitials)
+
+        let pageBounds = doc.page(at: 0)?.bounds(for: .mediaBox) ?? CGRect(x: 0, y: 0, width: 612, height: 792)
+        let renderer = UIGraphicsPDFRenderer(bounds: pageBounds)
+
         try renderer.writePDF(to: outURL) { ctx in
-            for pageIndex in 0..<doc.pageCount {
+            for i in 0..<doc.pageCount {
                 ctx.beginPage()
-                guard let page = doc.page(at: pageIndex) else { continue }
+                guard let page = doc.page(at: i) else { continue }
                 let cg = ctx.cgContext
 
-                // Draw original page
-                cg.saveGState()
+                // Draw original PDF page
                 page.draw(with: .mediaBox, to: cg)
-                cg.restoreGState()
 
-                // Only page 1 expected for this form, but code is safe if more pages exist.
-                // Top fields (Name/Rank, Platoon SGT/Unit, Date):
-                // We find anchors by text and place values to the right with a small offset.
-                overlayRight(ofText: "NAME", on: page, yNudge: 0,  draw: "PVT \(data.applicantName)", font: .systemFont(ofSize: 12), into: cg)
-                overlayRight(ofText: "RANK", on: page, yNudge: 0,  draw: "", font: .systemFont(ofSize: 12), into: cg) // tolerate variants
-                overlayRight(ofText: "PLATOON", on: page, yNudge: 0, draw: "\(data.recruiterName) / DET 3 RSP", font: .systemFont(ofSize: 12), into: cg)
-                overlayRight(ofText: "Date", on: page, yNudge: 0,   draw: d2, font: .systemFont(ofSize: 12), into: cg)
+                // Fonts
+                let big = UIFont.systemFont(ofSize: 12)
+                let small = UIFont.systemFont(ofSize: 10)
 
-                // Red Phase → Drill1 + initials
-                fillPhase(on: page,
-                          contains: "STRM Red Phase",
-                          initials: data.recruiterInitials,
-                          date: d1,
-                          into: cg)
+                // --- Top banner (anchor-based) ---
+                // NAME/RANK (left top)
+                overlayRight(ofAnyToken: ["NAME & RANK", "NAME", "NAME  RANK"],
+                             on: page,
+                             yNudge: 0,
+                             draw: topName,
+                             font: big,
+                             cg: cg)
 
-                // White Phase → Drill2 + initials
-                fillPhase(on: page,
-                          contains: "STRM White Phase",
-                          initials: data.recruiterInitials,
-                          date: d2,
-                          into: cg)
+                // PLATOON SGT / UNIT (left top)
+                overlayRight(ofAnyToken: ["PLATOON SGT/UNIT", "PLATOON", "UNIT"],
+                             on: page,
+                             yNudge: 0,
+                             draw: topUnit,
+                             font: big,
+                             cg: cg)
 
-                // We *intentionally* DO NOT touch ACFT Points/ACT score fields or bottom signatures.
+                // Date (top right) — choose a token at top 25% of the page to avoid line dates below
+                if let sel = firstToken("Date", on: page, topFraction: 0.25) {
+                    let r = sel.bounds(for: page)
+                    drawText(d2, at: CGPoint(x: r.maxX + 8, y: r.minY), font: big, cg: cg)
+                }
+
+                // --- Phase rows (anchor each line & draw near the right margin) ---
+                fillPhaseLines(on: page,
+                               contains: "STRM Red Phase",
+                               value: redText,
+                               font: small,
+                               cg: cg)
+
+                fillPhaseLines(on: page,
+                               contains: "STRM White Phase",
+                               value: whiteText,
+                               font: small,
+                               cg: cg)
             }
         }
 
         return outURL
     }
 
-    // MARK: - Helpers
+    // MARK: - Overlay helpers
 
-    /// Writes two small entries ("AB" and "01/02/25") near each anchor that contains the phase text.
-    /// We place them toward the right margin on the same line, with defensible default offsets.
-    private static func fillPhase(on page: PDFPage, contains phaseMarker: String, initials: String, date: String, into cg: CGContext) {
-        let anchors = selections(for: phaseMarker, on: page)
-        let font = UIFont.systemFont(ofSize: 10)
+    /// Find first match for a token near the top area (guards against other dates/signature regions).
+    private static func firstToken(_ token: String, on page: PDFPage, topFraction: CGFloat) -> PDFSelection? {
+        guard let doc = page.document else { return nil }
+        let hits = doc.findString(token, withOptions: .caseInsensitive)
+        let pageH = page.bounds(for: .mediaBox).height
+        return hits.first(where: { $0.pages.contains(page) && $0.bounds(for: page).minY <= pageH * topFraction })
+    }
 
-        for sel in anchors {
+    private static func overlayRight(ofAnyToken tokens: [String], on page: PDFPage, yNudge: CGFloat, draw value: String, font: UIFont, cg: CGContext) {
+        guard !value.isEmpty else { return }
+        for t in tokens {
+            guard let sel = selection(in: page, token: t) else { continue }
             let r = sel.bounds(for: page)
-            // Heuristic: the "Initials/Date of Completion" column is usually far right on same line.
-            // So we draw toward the right side of the page horizontally aligned with the anchor's midY.
-            let pageBounds = page.bounds(for: .mediaBox)
-            let y = r.midY - 4  // center-ish vertically on the line
-
-            // Draw initials, then date just to its right.
-            drawText(initials, at: CGPoint(x: pageBounds.maxX - 160, y: y), font: font, into: cg)
-            drawText(date,     at: CGPoint(x: pageBounds.maxX - 100, y: y), font: font, into: cg)
+            drawText(value, at: CGPoint(x: r.maxX + 8, y: r.minY + yNudge), font: font, cg: cg)
+            return
         }
     }
 
-    /// Find anchor by a (partial) text token and place a value just to the right of its bounding box.
-    private static func overlayRight(ofText token: String, on page: PDFPage, yNudge: CGFloat, draw value: String, font: UIFont, into cg: CGContext) {
-        guard let sel = selections(for: token, on: page).first else { return }
-        let r = sel.bounds(for: page)
+    private static func fillPhaseLines(on page: PDFPage, contains marker: String, value: String, font: UIFont, cg: CGContext) {
         guard !value.isEmpty else { return }
-        let point = CGPoint(x: r.maxX + 8, y: r.minY + yNudge)
-        drawText(value, at: point, font: font, into: cg)
+        let anchors = selections(in: page, token: marker)
+        let pageBounds = page.bounds(for: .mediaBox)
+        // Write toward the right column; tweak these X offsets if your template changes.
+        let initialsX = pageBounds.maxX - 160.0
+        let dateX     = pageBounds.maxX - 100.0
+
+        for s in anchors {
+            let r = s.bounds(for: page)
+            let y = r.midY - 4
+            // Fill as "Initials / Date of Completion" pair (initials left, date right)
+            // If you store initials separate, you could split here. We keep combined 'value'.
+            // Expect `value` like "05/10/25 / JS" or "05/10/25 JS", both OK.
+            // For stricter separation, parse and draw pieces at the two columns.
+            drawText(value, at: CGPoint(x: initialsX, y: y), font: font, cg: cg)
+            _ = dateX // placeholder for separate date column if needed later
+        }
     }
 
-    private static func drawText(_ text: String, at point: CGPoint, font: UIFont, into cg: CGContext) {
-        let attrs: [NSAttributedString.Key:Any] = [
+    private static func drawText(_ text: String, at p: CGPoint, font: UIFont, cg: CGContext) {
+        guard !text.isEmpty else { return }
+        let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: UIColor.black
         ]
-        (text as NSString).draw(at: point, withAttributes: attrs)
+        (text as NSString).draw(at: p, withAttributes: attrs)
     }
 
-    private static func selections(for token: String, on page: PDFPage) -> [PDFSelection] {
-        // Try exact first
-        if let sel = page.selection(for: token) {
-            return [sel]
-        }
-        // Fallback: find by scanning attributed string for the token (case-insensitive)
-        guard let full = page.attributedString?.string else { return [] }
-        let lower = full.lowercased()
-        let needle = token.lowercased()
-        guard let range = lower.range(of: needle) else { return [] }
-        let nsRange = NSRange(range, in: full)
-        if let s = page.selection(for: nsRange) { return [s] }
-        return []
-    }
-}
-
-private extension PDFPage {
-    /// Exact selection helper (PDFKit lacks a direct "selectionForString" API on iOS).
-    func selection(for string: String) -> PDFSelection? {
-        guard let doc = document else { return nil }
-        let all = doc.findString(string, withOptions: .caseInsensitive)
-        // Filter to this page only
-        return all.first { $0.pages.contains(self) }
+    private static func selection(in page: PDFPage, token: String) -> PDFSelection? {
+        guard let doc = page.document else { return nil }
+        let results = doc.findString(token, withOptions: .caseInsensitive)
+        return results.first { $0.pages.contains(page) }
     }
 
-    /// Build a selection from an NSRange in the page’s plain text if available.
-    func selection(for range: NSRange) -> PDFSelection? {
-        guard let attr = attributedString else { return nil }
-        guard range.location != NSNotFound, NSMaxRange(range) <= attr.length else { return nil }
-        let sel = PDFSelection(document: document!)
-        sel?.add(self)
-        // We cannot set the exact range directly; this is a best-effort approach using findString for substrings
-        // In practice, anchorFinding above will usually succeed via selection(for: string).
-        return sel
+    private static func selections(in page: PDFPage, token: String) -> [PDFSelection] {
+        guard let doc = page.document else { return [] }
+        let results = doc.findString(token, withOptions: .caseInsensitive)
+        return results.filter { $0.pages.contains(page) }
+    }
+
+    // MARK: - Field name helpers (AcroForm)
+
+    private static func safeFieldName(_ ann: PDFAnnotation) -> String {
+        if let n = ann.fieldName, !n.isEmpty { return n }
+        if let n = ann.value(forAnnotationKey: .fieldName) as? String, !n.isEmpty { return n }
+        if let n = ann.value(forAnnotationKey: PDFAnnotationKey(rawValue: "T")) as? String, !n.isEmpty { return n }
+        return ""
+    }
+
+    private static func equals(_ a: String, _ b: String) -> Bool {
+        return a.caseInsensitiveCompare(b) == .orderedSame
+    }
+
+    private static func containsAny(_ s: String, _ options: [String]) -> Bool {
+        options.contains { s.range(of: $0, options: .caseInsensitive) != nil }
+    }
+
+    private static func combine(date: String, initials: String) -> String {
+        guard !date.isEmpty, !initials.isEmpty else { return date.isEmpty ? initials : date }
+        return "\(date) / \(initials)"
     }
 }
-

--- a/StripesForSkillsFiller.swift
+++ b/StripesForSkillsFiller.swift
@@ -1,0 +1,143 @@
+import Foundation
+import PDFKit
+import UIKit
+
+struct StripesForSkillsData {
+    let applicantName: String       // e.g., "John Doe"
+    let recruiterName: String       // e.g., from Settings.recruiterName
+    let recruiterInitials: String   // e.g., from Settings.recruiterInitials
+    let drill1: Date?               // First drill (Red Phase)
+    let drill2: Date?               // Second drill (White Phase & top Date)
+}
+
+enum StripesForSkillsFiller {
+
+    // MARK: - Public entry point
+    static func fill(templateURL: URL, data: StripesForSkillsData) throws -> URL {
+        guard let doc = PDFDocument(url: templateURL), doc.pageCount > 0 else {
+            throw NSError(domain: "StripesFiller", code: -1, userInfo: [NSLocalizedDescriptionKey: "Template PDF not found or empty"])
+        }
+
+        let df = DateFormatter(); df.dateStyle = .short
+        let d1 = data.drill1.map { df.string(from: $0) } ?? ""
+        let d2 = data.drill2.map { df.string(from: $0) } ?? ""
+
+        // Render each page to a new PDF, drawing the original page, then our overlays.
+        let pageRect = doc.page(at: 0)?.bounds(for: .mediaBox) ?? CGRect(x: 0, y: 0, width: 612, height: 792)
+        let outURL = FileManager.default.temporaryDirectory.appendingPathComponent("STRIPES_\(UUID().uuidString).pdf")
+        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
+        try renderer.writePDF(to: outURL) { ctx in
+            for pageIndex in 0..<doc.pageCount {
+                ctx.beginPage()
+                guard let page = doc.page(at: pageIndex) else { continue }
+                let cg = ctx.cgContext
+
+                // Draw original page
+                cg.saveGState()
+                page.draw(with: .mediaBox, to: cg)
+                cg.restoreGState()
+
+                // Only page 1 expected for this form, but code is safe if more pages exist.
+                // Top fields (Name/Rank, Platoon SGT/Unit, Date):
+                // We find anchors by text and place values to the right with a small offset.
+                overlayRight(ofText: "NAME", on: page, yNudge: 0,  draw: "PVT \(data.applicantName)", font: .systemFont(ofSize: 12), into: cg)
+                overlayRight(ofText: "RANK", on: page, yNudge: 0,  draw: "", font: .systemFont(ofSize: 12), into: cg) // tolerate variants
+                overlayRight(ofText: "PLATOON", on: page, yNudge: 0, draw: "\(data.recruiterName) / DET 3 RSP", font: .systemFont(ofSize: 12), into: cg)
+                overlayRight(ofText: "Date", on: page, yNudge: 0,   draw: d2, font: .systemFont(ofSize: 12), into: cg)
+
+                // Red Phase → Drill1 + initials
+                fillPhase(on: page,
+                          contains: "STRM Red Phase",
+                          initials: data.recruiterInitials,
+                          date: d1,
+                          into: cg)
+
+                // White Phase → Drill2 + initials
+                fillPhase(on: page,
+                          contains: "STRM White Phase",
+                          initials: data.recruiterInitials,
+                          date: d2,
+                          into: cg)
+
+                // We *intentionally* DO NOT touch ACFT Points/ACT score fields or bottom signatures.
+            }
+        }
+
+        return outURL
+    }
+
+    // MARK: - Helpers
+
+    /// Writes two small entries ("AB" and "01/02/25") near each anchor that contains the phase text.
+    /// We place them toward the right margin on the same line, with defensible default offsets.
+    private static func fillPhase(on page: PDFPage, contains phaseMarker: String, initials: String, date: String, into cg: CGContext) {
+        let anchors = selections(for: phaseMarker, on: page)
+        let font = UIFont.systemFont(ofSize: 10)
+
+        for sel in anchors {
+            let r = sel.bounds(for: page)
+            // Heuristic: the "Initials/Date of Completion" column is usually far right on same line.
+            // So we draw toward the right side of the page horizontally aligned with the anchor's midY.
+            let pageBounds = page.bounds(for: .mediaBox)
+            let y = r.midY - 4  // center-ish vertically on the line
+
+            // Draw initials, then date just to its right.
+            drawText(initials, at: CGPoint(x: pageBounds.maxX - 160, y: y), font: font, into: cg)
+            drawText(date,     at: CGPoint(x: pageBounds.maxX - 100, y: y), font: font, into: cg)
+        }
+    }
+
+    /// Find anchor by a (partial) text token and place a value just to the right of its bounding box.
+    private static func overlayRight(ofText token: String, on page: PDFPage, yNudge: CGFloat, draw value: String, font: UIFont, into cg: CGContext) {
+        guard let sel = selections(for: token, on: page).first else { return }
+        let r = sel.bounds(for: page)
+        guard !value.isEmpty else { return }
+        let point = CGPoint(x: r.maxX + 8, y: r.minY + yNudge)
+        drawText(value, at: point, font: font, into: cg)
+    }
+
+    private static func drawText(_ text: String, at point: CGPoint, font: UIFont, into cg: CGContext) {
+        let attrs: [NSAttributedString.Key:Any] = [
+            .font: font,
+            .foregroundColor: UIColor.black
+        ]
+        (text as NSString).draw(at: point, withAttributes: attrs)
+    }
+
+    private static func selections(for token: String, on page: PDFPage) -> [PDFSelection] {
+        // Try exact first
+        if let sel = page.selection(for: token) {
+            return [sel]
+        }
+        // Fallback: find by scanning attributed string for the token (case-insensitive)
+        guard let full = page.attributedString?.string else { return [] }
+        let lower = full.lowercased()
+        let needle = token.lowercased()
+        guard let range = lower.range(of: needle) else { return [] }
+        let nsRange = NSRange(range, in: full)
+        if let s = page.selection(for: nsRange) { return [s] }
+        return []
+    }
+}
+
+private extension PDFPage {
+    /// Exact selection helper (PDFKit lacks a direct "selectionForString" API on iOS).
+    func selection(for string: String) -> PDFSelection? {
+        guard let doc = document else { return nil }
+        let all = doc.findString(string, withOptions: .caseInsensitive)
+        // Filter to this page only
+        return all.first { $0.pages.contains(self) }
+    }
+
+    /// Build a selection from an NSRange in the page’s plain text if available.
+    func selection(for range: NSRange) -> PDFSelection? {
+        guard let attr = attributedString else { return nil }
+        guard range.location != NSNotFound, NSMaxRange(range) <= attr.length else { return nil }
+        let sel = PDFSelection(document: document!)
+        sel?.add(self)
+        // We cannot set the exact range directly; this is a best-effort approach using findString for substrings
+        // In practice, anchorFinding above will usually succeed via selection(for: string).
+        return sel
+    }
+}
+


### PR DESCRIPTION
## Summary
- overlay applicant details on Stripes for Skills template via new `StripesForSkillsFiller`
- add button on SAS detail screen to generate and share filled Stripes PDF

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a3abfbf50c8321b636f06820a8fdfd